### PR TITLE
Added synchronized flushing with Magento's cache & all required changes henceforth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Utility for managing Redis services
 3. Delete cache keys by matched strings
 4. Auto-refresh redis dashboard every X seconds
 5. View usage statistics
-
+6. Synchonize to Magento flushes: Redismanager listens for the flush_system and flush_all (basically both top-right cache flush buttons on the Cache control page) events and (if enabled) flushes all Redis instances. (If you use Redis for your session management, be sure to use manual configuration and do NOT include the Cm_RedisSession instance).
 
 # Screenshots
 
@@ -50,6 +50,8 @@ Utility for managing Redis services
   * You may have incorrectly configured your settings.  Check you settings in System > Config > Advanced > Redis Management.  Double check your Manual Configuration or try changing `Automatically detect Redis services` to `Yes`
 * What versions of Magento are supported?
   * This module has been tested on CE 1.7, 1.8, 1.9 and EE 1.12, 1.13, 1.14, however it should work with any version.
+* Has the module been translated?
+  * Yes. From the original English (en_EN) to Korean (ko_KR) and Dutch (nl_NL).. feel free to contribute!
 
 # Support
 

--- a/modman
+++ b/modman
@@ -4,4 +4,5 @@ src/app/design/adminhtml/default/default/layout/steverobbins/redismanager.xml ap
 src/app/design/adminhtml/default/default/template/steverobbins/redismanager   app/design/adminhtml/default/default/template/steverobbins/redismanager
 src/app/locale/en_US/Steverobbins_Redismanager.csv                            app/locale/en_US/Steverobbins_Redismanager.csv
 src/app/locale/ko_KR/Steverobbins_Redismanager.csv                            app/locale/ko_KR/Steverobbins_Redismanager.csv
+src/app/locale/nl_NL/Steverobbins_Redismanager.csv                            app/locale/nl_NL/Steverobbins_Redismanager.csv
 src/skin/adminhtml/default/default/steverobbins/redismanager                  skin/adminhtml/default/default/steverobbins/redismanager

--- a/src/app/code/community/Steverobbins/Redismanager/Model/Backend/Redis/Cm.php
+++ b/src/app/code/community/Steverobbins/Redismanager/Model/Backend/Redis/Cm.php
@@ -22,8 +22,7 @@
  * @license   http://creativecommons.org/licenses/by/3.0/deed.en_US Creative Commons Attribution 3.0 Unported License
  * @link      https://github.com/steverobbins/Magento-Redismanager
  */
-class Steverobbins_Redismanager_Model_Backend_Redis_Cm
-    extends Cm_Cache_Backend_Redis
+class Steverobbins_Redismanager_Model_Backend_Redis_Cm extends Cm_Cache_Backend_Redis
 {
     /**
      * Get redis client

--- a/src/app/code/community/Steverobbins/Redismanager/Model/Observer.php
+++ b/src/app/code/community/Steverobbins/Redismanager/Model/Observer.php
@@ -1,5 +1,27 @@
 <?php
+/**
+ * Redis Management Module
+ *
+ * PHP Version 5
+ *
+ * @category  Steverobbins
+ * @package   Steverobbins_Redismanager
+ * @author    Steve Robbins <steven.j.robbins@gmail.com>
+ * @copyright 2014 Steve Robbins
+ * @license   http://creativecommons.org/licenses/by/3.0/deed.en_US Creative Commons Attribution 3.0 Unported License
+ * @link      https://github.com/steverobbins/Magento-Redismanager
+ */
 
+/**
+ * Redis manager observer class
+ *
+ * @category  Steverobbins
+ * @package   Steverobbins_Redismanager
+ * @author    Henry van Megen <h.van.megen@gmail.com>
+ * @copyright 2018 Henry van Megen
+ * @license   http://creativecommons.org/licenses/by/3.0/deed.en_US Creative Commons Attribution 3.0 Unported License
+ * @link      https://github.com/steverobbins/Magento-Redismanager
+ */
 class Steverobbins_Redismanager_Model_Observer
 {
     /**
@@ -10,11 +32,13 @@ class Steverobbins_Redismanager_Model_Observer
     protected $_helper;
 
     /**
+     * Event observer for adminhtml_cache_flush_system event
+     *
      * @param Varien_Event_Observer $observer
      *
      * @return $this
      */
-    public function adminhtml_cache_flush_system(Varien_Event_Observer $observer)
+    public function cacheFlushSystem(Varien_Event_Observer $observer)
     {
         try {
             $this->_getHelper()->flushAllByObserver();
@@ -25,17 +49,19 @@ class Steverobbins_Redismanager_Model_Observer
     }
 
     /**
+     * Event observer for adminhtml_cache_flush_all event
+     *
      * @param Varien_Event_Observer $observer
      *
      * @return $this
      */
-    public function adminhtml_cache_flush_all(Varien_Event_Observer $observer)
+    public function cacheFlushAll(Varien_Event_Observer $observer)
     {
         try {
             $this->_getHelper()->flushAllByObserver();
         } catch (Exception $e) {
             Mage::logException($e);
-        } 
+        }
         return $this;
     }
 
@@ -44,11 +70,11 @@ class Steverobbins_Redismanager_Model_Observer
      *
      * @return Steverobbins_Redismanager_Helper_Data
      */
-     protected function _getHelper()
-     {
-         if (is_null($this->_helper)) {
-             $this->_helper = Mage::helper('redismanager');
-         }
-         return $this->_helper;
-     }
+    protected function _getHelper()
+    {
+        if (is_null($this->_helper)) {
+            $this->_helper = Mage::helper('redismanager');
+        }
+        return $this->_helper;
+    }
 }

--- a/src/app/code/community/Steverobbins/Redismanager/Model/Observer.php
+++ b/src/app/code/community/Steverobbins/Redismanager/Model/Observer.php
@@ -1,0 +1,54 @@
+<?php
+
+class Steverobbins_Redismanager_Model_Observer
+{
+    /**
+     * Cached helper
+     *
+     * @var Steverobbins_Redismanager_Helper_Data
+     */
+    protected $_helper;
+
+    /**
+     * @param Varien_Event_Observer $observer
+     *
+     * @return $this
+     */
+    public function adminhtml_cache_flush_system(Varien_Event_Observer $observer)
+    {
+        try {
+            $this->_getHelper()->flushAllByObserver();
+        } catch (Exception $e) {
+            Mage::logException($e);
+        }
+        return $this;
+    }
+
+    /**
+     * @param Varien_Event_Observer $observer
+     *
+     * @return $this
+     */
+    public function adminhtml_cache_flush_all(Varien_Event_Observer $observer)
+    {
+        try {
+            $this->_getHelper()->flushAllByObserver();
+        } catch (Exception $e) {
+            Mage::logException($e);
+        } 
+        return $this;
+    }
+
+    /**
+     * Get helper
+     *
+     * @return Steverobbins_Redismanager_Helper_Data
+     */
+     protected function _getHelper()
+     {
+         if (is_null($this->_helper)) {
+             $this->_helper = Mage::helper('redismanager');
+         }
+         return $this->_helper;
+     }
+}

--- a/src/app/code/community/Steverobbins/Redismanager/Model/Source/Manual.php
+++ b/src/app/code/community/Steverobbins/Redismanager/Model/Source/Manual.php
@@ -22,8 +22,7 @@
  * @license   http://creativecommons.org/licenses/by/3.0/deed.en_US Creative Commons Attribution 3.0 Unported License
  * @link      https://github.com/steverobbins/Magento-Redismanager
  */
-class Steverobbins_Redismanager_Model_Source_Manual
-    extends Mage_Adminhtml_Model_System_Config_Backend_Serialized_Array
+class Steverobbins_Redismanager_Model_Source_Manual extends Mage_Adminhtml_Model_System_Config_Backend_Serialized_Array
 {
     /**
      * Event prefix for observers

--- a/src/app/code/community/Steverobbins/Redismanager/controllers/Adminhtml/RedismanagerController.php
+++ b/src/app/code/community/Steverobbins/Redismanager/controllers/Adminhtml/RedismanagerController.php
@@ -148,28 +148,9 @@ class Steverobbins_Redismanager_Adminhtml_RedismanagerController
     public function flushAllAction()
     {
         $flushThis = $this->getRequest()->getParam('host', null);
-        $flushed   = array();
-        foreach ($this->_getHelper()->getServices() as $service) {
-            $serviceMatch = $service['host'] . ':' . $service['port'];
-            if (in_array($serviceMatch, $flushed)
-                || (!is_null($flushThis) && $flushThis != $serviceMatch)
-            ) {
-                continue;
-            }
-            try {
-                $this->_getHelper()->getRedisInstance(
-                    $service['host'],
-                    $service['port'],
-                    $service['password'],
-                    $service['db']
-                )->getRedis()->flushAll();
-                $flushed[] = $serviceMatch;
-                Mage::getSingleton('core/session')->addSuccess($this->__('%s flushed', $serviceMatch));
-            } catch (Exception $e) {
-                Mage::getSingleton('core/session')->addError($e->getMessage());
-            }
+        if (is_array($this->_getHelper()->flushAll($flushThis))) {
+            $this->_redirect('*/*');
         }
-        $this->_redirect('*/*');
     }
 
     /**
@@ -214,7 +195,7 @@ class Steverobbins_Redismanager_Adminhtml_RedismanagerController
                 $service['db']
             );
             $redis->clean(Zend_Cache::CLEANING_MODE_ALL);
-            Mage::getSingleton('core/session')->addSuccess($this->__('%s database flushed', $service['name']));
+            Mage::getSingleton('core/session')->addSuccess($this->__('%s database flushed.', $service['name']));
         } catch (Exception $e) {
             Mage::getSingleton('core/session')->addError($e->getMessage());
         }

--- a/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
+++ b/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
@@ -14,7 +14,7 @@
 <config>
     <modules>
         <Steverobbins_Redismanager>
-            <version>1.4.3</version>
+            <version>1.4.5</version>
         </Steverobbins_Redismanager>
     </modules>
     <global>
@@ -62,6 +62,26 @@
                 </Steverobbins_Redismanager>
             </modules>
         </translate>
+        <events>
+            <adminhtml_cache_flush_all>
+                <observers>
+                    <mageboost>
+                        <type>singleton</type>
+                        <class>redismanager/observer</class>
+                        <method>adminhtml_cache_flush_all</method>
+                    </mageboost>
+                </observers>
+            </adminhtml_cache_flush_all>
+            <adminhtml_cache_flush_system>
+                <observers>
+                    <mageboost>
+                        <type>singleton</type>
+                        <class>redismanager/observer</class>
+                        <method>adminhtml_cache_flush_system</method>
+                    </mageboost>
+                </observers>
+            </adminhtml_cache_flush_system>
+        </events>
     </adminhtml>
     <default>
         <redismanager>

--- a/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
+++ b/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
@@ -14,7 +14,7 @@
 <config>
     <modules>
         <Steverobbins_Redismanager>
-            <version>1.4.5</version>
+            <version>1.4.4</version>
         </Steverobbins_Redismanager>
     </modules>
     <global>

--- a/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
+++ b/src/app/code/community/Steverobbins/Redismanager/etc/config.xml
@@ -68,7 +68,7 @@
                     <mageboost>
                         <type>singleton</type>
                         <class>redismanager/observer</class>
-                        <method>adminhtml_cache_flush_all</method>
+                        <method>cacheFlushAll</method>
                     </mageboost>
                 </observers>
             </adminhtml_cache_flush_all>
@@ -77,7 +77,7 @@
                     <mageboost>
                         <type>singleton</type>
                         <class>redismanager/observer</class>
-                        <method>adminhtml_cache_flush_system</method>
+                        <method>cacheFlushSystem</method>
                     </mageboost>
                 </observers>
             </adminhtml_cache_flush_system>
@@ -87,6 +87,7 @@
         <redismanager>
             <settings>
                 <auto>1</auto>
+                <syncflush>0</syncflush>
             </settings>
         </redismanager>
     </default>

--- a/src/app/code/community/Steverobbins/Redismanager/etc/system.xml
+++ b/src/app/code/community/Steverobbins/Redismanager/etc/system.xml
@@ -59,7 +59,6 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event.</comment>
-                            <depends><auto>0</auto></depends>
                         </syncflush>
                     </fields>
                 </settings>

--- a/src/app/code/community/Steverobbins/Redismanager/etc/system.xml
+++ b/src/app/code/community/Steverobbins/Redismanager/etc/system.xml
@@ -40,16 +40,27 @@
                             <show_in_store>0</show_in_store>
                             <comment>If No, use manual configuration below</comment>
                         </auto>
-                        <manual translate="label">
+                        <manual translate="label comment">
                             <label>Manual Configuration</label>
                             <frontend_model>redismanager/adminhtml_system_config_form_field_manual</frontend_model>
                             <backend_model>redismanager/source_manual</backend_model>
-                            <validate>required-entry</validate>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <comment>When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost.</comment>
                         </manual>
+                        <syncflush translate="label comment">
+                            <label>Synchronize with Magento cache flushes</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <comment>Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event.</comment>
+                            <depends><auto>0</auto></depends>
+                        </syncflush>
                     </fields>
                 </settings>
             </groups>

--- a/src/app/locale/en_US/Steverobbins_Redismanager.csv
+++ b/src/app/locale/en_US/Steverobbins_Redismanager.csv
@@ -1,4 +1,6 @@
-"%s database flushed","%s database flushed"
+"%s key(s) cleared","%s key(s) cleared"
+"%s database flushed.","%s database flushed."
+"Refresh every %s seconds","Refresh every %s seconds"
 "Automatically detect Redis services","Automatically detect Redis services"
 Back,Back
 "Connected Clients","Connected Clients"
@@ -31,3 +33,7 @@ System,System
 Uptime,Uptime
 "View Keys","View Keys"
 view,view
+"When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost.","When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost."
+"Synchronize with Magento cache flushes","Synchronize with Magento cache flushes"
+"Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event.","Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event."
+"Redismanager has observed a cache flush by Magento, flushing Redis...","Redismanager has observed a cache flush by Magento, flushing Redis..."

--- a/src/app/locale/ko_KR/Steverobbins_Redismanager.csv
+++ b/src/app/locale/ko_KR/Steverobbins_Redismanager.csv
@@ -1,4 +1,6 @@
-"%s database flushed","%s 데이터베이스를 비웠습니다"
+"%s key(s) cleared","%s key(s) cleared"
+"%s database flushed.","%s 데이터베이스를 비웠습니다"
+"Refresh every %s seconds","Refresh every %s seconds"
 "Automatically detect Redis services","자동적으로 Redis서비스 찾아내기"
 Back,뒤로가기
 "Connected Clients","연결된 클라이언트"
@@ -31,3 +33,7 @@ System,시스템
 Uptime,가동시간
 "View Keys","키 보기"
 view,보기
+"When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost.","When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost."
+"Synchronize with Magento cache flushes","Synchronize with Magento cache flushes"
+"Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event.","Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event."
+"Redismanager has observed a cache flush by Magento, flushing Redis...","Redismanager has observed a cache flush by Magento, flushing Redis..."

--- a/src/app/locale/nl_NL/Steverobbins_Redismanager.csv
+++ b/src/app/locale/nl_NL/Steverobbins_Redismanager.csv
@@ -1,0 +1,39 @@
+"%s key(s) cleared","%s key(s) opgeschoond"
+"%s database flushed.","%s database geflushed."
+"Refresh every %s seconds","Ververs iedere %s seconden"
+"Automatically detect Redis services","Automatisch Redis services detecteren"
+Back,Terug
+"Connected Clients","Verbonden Clients"
+Database,Database
+"Delete Keys","Verwijder Keys"
+"Delete Matching Keys","Verwijder Overeenkomende Keys"
+"Flush DB","Flush DB"
+"Flush Databases","Flush Databases"
+Host,Host
+"If No, use manual configuration below","Wanneer Nee, gebruik handmatige configuratie hieronder"
+Keys,Keys
+"Keys for %s","Keys voor %s"
+"Last Save","Laatst Opgeslagen"
+"Manual Configuration","Handmatige Configuratie"
+"Matched Keys (one per line):","Overeenkomende Keys (een per regel):"
+"Memory / Peak Memory","Geheugenverbruik / Piek Geheugenverbruik"
+Name,Naam
+"No Redis services were found.","Geen Redis services werden gevonden."
+Port,Poort
+"Redis Caches & Sessions","Redis Caches & Sessions"
+"Redis Manager","Redis Manager"
+Role,Rol
+Session,Sessie
+Settings,Instellingen
+Slaves,Slaves
+Statistics,Statistieken
+System,Systeem
+"Total: %s","Totaal: %s"
+"Unable to flush Redis database","Kan Redis database niet flushen"
+Uptime,Uptime
+"View Keys","Bekijk Keys"
+view,bekijk
+"When using the synchronized flushes and Cm_RedisSession, it is recommended that the Cm_RedisSession database is not listed here so that no sessions are lost.","Wanneer je de gesynchroniseerde flushes samen met Cm_RedisSession gebruikt is het aan te raden om de Cm_RedisSession database niet op te geven zodat er geen sessies verloren gaan."
+"Synchronize with Magento cache flushes","Synchroniseer met Magento cache flushes"
+"Flush all specified Redis databases whenever Magento fires an adminhtml_cache_flush_system OR adminhtml_cache_flush_all observer event.","Flush alle Redis databases wanneer Magento een adminhtml_cache_flush_system OF adminhtml_cache_flush_all observer event afvuurt."
+"Redismanager has observed a cache flush by Magento, flushing Redis...","Redismanager heeft een cache flush van Magento voorbij zien komen, bezig met flushen van Redis..."


### PR DESCRIPTION
Added synchronized flushing with Magento's cache because I felt like making my customers feel like morons by having to flush their caches on 2 separate pages.

- Added observers to listen for **_adminhtml_cache_flush_system_** and **_adminhtml_cache_flush_all_** events and perform a flushAll accordingly.
- Added Dutch translations
- Added adminhtml interface configuration to set up synchronized flushing
- Added extra help comment (and translations).
- Updated the modman file
- Changed the README.md file to reflect the changes

I had to move some functionality from the controller to the helper in order to call it easily from my Observer.php.

The synchronized flushing is disabled by default, so existing installations should have no issues.

I could not translate the newly added translatable strings to Korean, but I left the english ones in there.